### PR TITLE
게시글에서 채팅방 생성 후 이동, 원글보기 버튼 연결

### DIFF
--- a/app/src/main/java/com/example/sport_planet/data/response/chatting/ChattingMessageResponse.kt
+++ b/app/src/main/java/com/example/sport_planet/data/response/chatting/ChattingMessageResponse.kt
@@ -10,26 +10,26 @@ import kotlinx.serialization.Serializable
 data class ChattingMessageResponse (
 
     @SerializedName("id")
-    val id: Long?,
+    val id: Long,
     @SerializedName("content")
-    val content: String?,
+    val content: String,
     @SerializedName("type")
-    val type: String?,
+    val type: String,
     @SerializedName("realTimeUpdateType")
-    val realTimeUpdateType: String?,
+    val realTimeUpdateType: String,
     @SerializedName("isHostRead")
-    val isHostRead: Boolean?,
+    val isHostRead: Boolean,
     @SerializedName("isGuestRead")
-    val isGuestRead: Boolean?,
+    val isGuestRead: Boolean,
     @SerializedName("messageId")
-    val messageId: Long?,
+    val messageId: Long,
     @SerializedName("chatRoomId")
-    val chatRoomId: Long?,
+    val chatRoomId: Long,
     @SerializedName("senderId")
-    val senderId: Long?,
+    val senderId: Long,
     @SerializedName("senderNickname")
-    val senderNickname: String?,
+    val senderNickname: String,
     @SerializedName("createdAt")
-    val createdAt: String?
+    val createdAt: String
 
 ): Parcelable

--- a/app/src/main/java/com/example/sport_planet/data/response/chatting/MakeChattingRoomResponse.kt
+++ b/app/src/main/java/com/example/sport_planet/data/response/chatting/MakeChattingRoomResponse.kt
@@ -18,15 +18,15 @@ data class MakeChattingRoomResponse (
     @Parcelize
     data class Data(
         @SerializedName("id")
-        val id: Int,
+        val id: Long,
         @SerializedName("hostId")
-        val hostId: Int,
+        val hostId: Long,
         @SerializedName("guestId")
-        val guestId: Int,
+        val guestId: Long,
         @SerializedName("boardId")
-        val boardId: Int,
-        @SerializedName("status")
-        val status: String,
+        val boardId: Long,
+        @SerializedName("opponentNickname")
+        val opponentNickname: String,
         @SerializedName("createdAt")
         val createdAt: String
     ): Parcelable

--- a/app/src/main/java/com/example/sport_planet/presentation/board/BoardActivity.kt
+++ b/app/src/main/java/com/example/sport_planet/presentation/board/BoardActivity.kt
@@ -11,8 +11,11 @@ import com.example.sport_planet.R
 import com.example.sport_planet.data.enums.MenuEnum
 import com.example.sport_planet.data.enums.SeparatorEnum
 import com.example.sport_planet.data.model.MenuModel
+import com.example.sport_planet.data.model.chatting.ChatRoomInfo
 import com.example.sport_planet.databinding.ActivityBoardBinding
 import com.example.sport_planet.presentation.base.BaseActivity
+import com.example.sport_planet.presentation.chatting.UserInfo
+import com.example.sport_planet.presentation.chatting.view.ChattingActivity
 import com.example.sport_planet.remote.RemoteDataSourceImpl
 import kotlinx.android.synthetic.main.item_custom_toolbar.view.*
 
@@ -81,7 +84,22 @@ class BoardActivity : BaseActivity<ActivityBoardBinding>(R.layout.activity_board
         binding.toolbar.setBackButtonClick(View.OnClickListener { this.finish() })
 
         binding.btnChatting.setOnClickListener {
-
+            viewModel.makeChattingRoom()
+            viewModel.makeChattingRoomtResultLiveData.observe(this,
+                Observer {
+                    val intent = Intent(applicationContext, ChattingActivity::class.java)
+                    intent.putExtra("chatRoomInfo",
+                        ChatRoomInfo(
+                            it.data.id,
+                            it.data.boardId,
+                            it.data.guestId,
+                            it.data.hostId == UserInfo.USER_ID,
+                            it.data.opponentNickname
+                        )
+                    )
+                    startActivity(intent)
+                }
+            )
         }
     }
 

--- a/app/src/main/java/com/example/sport_planet/presentation/chatting/view/ChattingActivity.kt
+++ b/app/src/main/java/com/example/sport_planet/presentation/chatting/view/ChattingActivity.kt
@@ -15,6 +15,7 @@ import com.example.sport_planet.data.model.chatting.ChattingMessageModel
 import com.example.sport_planet.data.response.chatting.ChattingMessageResponse
 import com.example.sport_planet.databinding.ActivityChattingBinding
 import com.example.sport_planet.presentation.base.BaseActivity
+import com.example.sport_planet.presentation.board.BoardActivity
 import com.example.sport_planet.presentation.chatting.ChattingConstant
 import com.example.sport_planet.presentation.chatting.adapter.ChattingAdapter
 import com.example.sport_planet.presentation.chatting.viewmodel.ChattingActivityViewModel
@@ -22,7 +23,6 @@ import com.example.sport_planet.presentation.custom.CustomDialog
 import com.example.sport_planet.util.Util
 import kotlinx.android.synthetic.main.activity_chatting.*
 import kotlinx.android.synthetic.main.item_custom_approval_button.*
-import kotlinx.android.synthetic.main.item_custom_toolbar.view.*
 import kotlin.collections.ArrayList
 import kotlin.properties.Delegates
 
@@ -99,11 +99,11 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
 
                     chattingMessages.add(
                         ChattingMessageModel(
-                            chattingMessage.content!!,
-                            chattingMessage.type!!,
-                            chattingMessage.messageId!!,
-                            chattingMessage.senderId!!,
-                            chattingMessage.senderNickname!!,
+                            chattingMessage.content,
+                            chattingMessage.type,
+                            chattingMessage.messageId,
+                            chattingMessage.senderId,
+                            chattingMessage.senderNickname,
                             thisDate,
                             thisTime,
                             isSameDate,
@@ -114,16 +114,15 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
 
                 chattingAdapter.settingChattingMessageList(chattingMessages)
 
-                rv_activity_chatting_recyclerview.postDelayed(Runnable {
-                    (rv_activity_chatting_recyclerview.layoutManager as LinearLayoutManager).stackFromEnd = isPageFilledWithItems
-                    if (it.firstUnreadMessageId != -1)
-                        rv_activity_chatting_recyclerview.scrollToPosition(it.firstUnreadMessageId)
-                    if(!isPageFilledWithItems)
-                        rv_activity_chatting_recyclerview.addOnLayoutChangeListener(layoutChangeListener)
-                    rv_activity_chatting_recyclerview.postDelayed(Runnable {
-                        view_activity_chatting_loading.visibility = View.GONE
-                    },100)
-                },10)
+                (rv_activity_chatting_recyclerview.layoutManager as LinearLayoutManager).stackFromEnd = isPageFilledWithItems
+                if (it.firstUnreadMessageId != -1)
+                    rv_activity_chatting_recyclerview.scrollToPosition(it.firstUnreadMessageId)
+                if(!isPageFilledWithItems)
+                    rv_activity_chatting_recyclerview.addOnLayoutChangeListener(layoutChangeListener)
+
+                rv_activity_chatting_recyclerview.postDelayed({
+                    view_activity_chatting_loading.visibility = View.GONE
+                },100)
             }
         )
 
@@ -143,10 +142,10 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
 
         chattingActivityViewModel.noticeMessageLiveData.observe(this,
             Observer {
-                thisDate = Util.toDateFormat(it.createdAt!!)
+                thisDate = Util.toDateFormat(it.createdAt)
                 thisTime = Util.toTimeFormat(it.createdAt)
 
-                if(it.messageId!! > 0) {
+                if(it.messageId > 0) {
                     priorDate = chattingMessages[it.messageId.toInt() - 1].createdDate
                     isSameDate = priorDate == thisDate
                 }
@@ -156,11 +155,11 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
 
                 chattingAdapter.addChattingMessage(
                     ChattingMessageModel(
-                        it.content!!,
-                        it.type!!,
+                        it.content,
+                        it.type,
                         it.messageId,
-                        it.senderId!!,
-                        it.senderNickname!!,
+                        it.senderId,
+                        it.senderNickname,
                         thisDate,
                         thisTime,
                         isSameDate,
@@ -177,11 +176,11 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
                 chattingMessageFactory(it, true)
                 chattingAdapter.addChattingMessage(
                     ChattingMessageModel(
-                        it.content!!,
-                        it.type!!,
-                        it.messageId!!,
-                        it.senderId!!,
-                        it.senderNickname!!,
+                        it.content,
+                        it.type,
+                        it.messageId,
+                        it.senderId,
+                        it.senderNickname,
                         thisDate,
                         thisTime,
                         isSameDate,
@@ -203,6 +202,10 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
                 Toast.makeText(this, R.string.activity_chatting_toast, Toast.LENGTH_SHORT).show()
             }
         })
+
+        bt_activity_chatting_visit_original_board.setOnClickListener {
+            BoardActivity.createInstance(this, chatRoomInfo.boardId)
+        }
 
         bt_custom_approval_button.setOnClickListener {
             when(chattingActivityViewModel.approvalStatusLiveData.value){
@@ -236,10 +239,10 @@ class ChattingActivity : BaseActivity<ActivityChattingBinding>(R.layout.activity
     }
 
     private fun chattingMessageFactory(chattingMessage: ChattingMessageResponse, update: Boolean){
-        thisDate = Util.toDateFormat(chattingMessage.createdAt!!)
+        thisDate = Util.toDateFormat(chattingMessage.createdAt)
         thisTime = Util.toTimeFormat(chattingMessage.createdAt)
 
-        if(chattingMessage.messageId!! > 0) {
+        if(chattingMessage.messageId > 0) {
             val priorMessageId = chattingMessage.messageId.toInt() - 1
 
             priorDate = chattingMessages[priorMessageId].createdDate

--- a/app/src/main/java/com/example/sport_planet/presentation/chatting/viewmodel/ChattingActivityViewModel.kt
+++ b/app/src/main/java/com/example/sport_planet/presentation/chatting/viewmodel/ChattingActivityViewModel.kt
@@ -124,7 +124,7 @@ class ChattingActivityViewModel(private val chatRoomInfo: ChatRoomInfo) : BaseVi
                             .subscribe ({ stompMessage ->
                                 chattingMessage = Json.parse(ChattingMessageResponse.serializer(), stompMessage)
                                 when(chattingMessage.realTimeUpdateType) {
-                                    "MESSAGE_READ" -> {
+                                    ChattingConstant.REAL_TIME_MESSAGE_READ -> {
                                         when(chattingMessage.type){
                                             ChattingConstant.CHAT_BOT_MESSAGE -> _noticeMessageLiveData.postValue(chattingMessage)
                                             else -> _chattingMessageLiveData.postValue(chattingMessage)

--- a/app/src/main/java/com/example/sport_planet/util/Util.kt
+++ b/app/src/main/java/com/example/sport_planet/util/Util.kt
@@ -11,7 +11,7 @@ object Util {
         return TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,
             dp,
-            context?.resources?.displayMetrics
+            context.resources?.displayMetrics
         )
     }
 


### PR DESCRIPTION
- 게시글에서 채팅방 생성 후 이동하는 기능 추가(이미 채팅방이 존재하면 이동만)
- 원글보기 버튼에 원 게시글 페이지 연결
- ChattingMessageResponse 프로퍼티 Nullable -> Null Safe로 변경